### PR TITLE
Allowing CSeal to set otype to any value between 0 and 7 for EX capabilities

### DIFF
--- a/src/cheri_insts.sail
+++ b/src/cheri_insts.sail
@@ -715,7 +715,8 @@ function clause execute (CSeal(cd, cs1, cs2)) = {
         1 => true, /* otype_sentry */
         2 => true, /* otype_sentry_id */
         3 => true, /* otype_sentry_ie */
-        /* 4 and 5 are reserved */
+        4 => true, /* otype_sentry_bid */
+        5 => true, /* otype_sentry_bie */
         6 => true,
         7 => true,
         _ => false


### PR DESCRIPTION
Previously we had otype 4 and 5 being reserved and CSeal can't seal to those types (will clear tag). With PR#54, 4 and 5 are now defined as backward sentries so it seems logical to allow CSeal to create those otypes.