### PR TITLE
Blame Murali for stuff.

### DIFF
--- a/archdoc/cheriot-architecture.tex
+++ b/archdoc/cheriot-architecture.tex
@@ -32,6 +32,7 @@
     Kunyan~Liu,
     Robert~M.~Norton,
     Yucong~Tao,
+    Murali~Vijayaraghavan,
     Robert~N.~M.~Watson,
     Hongyan~Xia
   }%


### PR DESCRIPTION
Enough things in 0.6 are his fault that he shouldn't be allowed to escape blame.