### PR TITLE
Document SCRs implemented on Ibex.

### DIFF
--- a/archdoc/chap-changes.tex
+++ b/archdoc/chap-changes.tex
@@ -58,5 +58,6 @@
     \item[\ghpr{97}] Introduce the \asm{CHERIOT\_CCALL} relocation. This addresses difficulties with relaxation of compartment call relocations as per 
     \href{https://github.com/CHERIoT-Platform/llvm-project/pull/114}{CHERIoT-Platform/llvm-project/pull/114}.
     \item[\ghpr{104}, \ghpr{105}] Modify the scalar calling convention ABI to more efficiently use capability registers for small records and 64-bit floating values.
+    \item[\ghpr{106}] Document the debug SCRs and reserve number for ZTopC. These were already implemented in Ibex but not documented here.
   \end{description}
 \end{description}

--- a/archdoc/chap-cheri-riscv.tex
+++ b/archdoc/chap-cheri-riscv.tex
@@ -165,6 +165,10 @@ They are accessed via a new instruction, \insnriscvref{CSpecialRW}, which behave
   \begin{tabular}{clcccc@{}}
     \toprule
     & \textbf{Register} & \textbf{Reset} & \textbf{Replaces} \\ \midrule
+    \textbf{24} & Debug program counter capability (\DEPCC{})   & $0$       & \asm{dpc} \\
+    \textbf{25} & Debug scratch capability 0 (\DScratchCO{})    & $0$       & \asm{dscratch0} \\
+    \textbf{26} & Debug scratch capability 1 (\DScratchCI{})    & $0$       & \asm{dscratch1} \\
+    \textbf{27} & Reserved (ZTopC)                           & $0$       & -        \\
     \textbf{28} & Machine trap code capability (\MTCC{})     & \caprootX & \mtvec{} \\
     \textbf{29} & Machine trap data capability (\MTDC{})     & \caprootM & -        \\
     \textbf{30} & Machine scratch capability (\MScratchC{})  & \caprootS & -        \\
@@ -176,7 +180,8 @@ They are accessed via a new instruction, \insnriscvref{CSpecialRW}, which behave
   }
 \end{table}
 
-The \MTCC{} and \MEPCC{} SCRs replace existing RISC-V CSRs \asm{mtvec} and \asm{mepcc} respectively.
+The \MTCC{} and \MEPCC{} SCRs replace existing RISC-V CSRs \mtvec{} and \mepc{} respectively.
+If debug mode is supported then \DEPCC{}, \DScratchCO{} and \DScratchCI{} are simply the equivalent debug CSRs extended to capabilities.
 Attempting to access the legacy RISC-V CSR via the \asm{CSR*} instructions results in a Reserved Instruction exception.
 The special meaning associated with the CSR applies to the SCR's \caddress{} field and the value written is validated and legalized as follows:
 

--- a/archdoc/preamble.tex
+++ b/archdoc/preamble.tex
@@ -261,6 +261,9 @@
 \newcommand{\uccsr}{\texttt{uccsr}}
 \newcommand{\mshwm}{\texttt{mshwm}}
 \newcommand{\mshwmb}{\texttt{mshwmb}}
+\newcommand{\DScratchCO}{{\bf DScratchC0}}
+\newcommand{\DScratchCI}{{\bf DScratchC1}}
+\newcommand{\DEPCC}{{\bf DEPCC}}
 % RISC-V existing registers
 \newcommand{\xtval}{\texttt{{\it x}tval}}
 \newcommand{\xtvec}{\texttt{{\it x}tvec}}


### PR DESCRIPTION
The debug SCRs were implemented on Ibex but not mentioned in the arch doc.
This isn't really complete as there are still some unanswered questions about debug mode behaviour and the Ibex implementation.
At some point we should describe the stack zeroizer but maybe after we've got it working.
