### PR TITLE
Enable bit manipulation extensions in the Sail model.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,12 @@ SAIL_DEFAULT_INST = $(SAIL_RISCV_MODEL_DIR)/riscv_insts_base.sail \
                     $(SAIL_RISCV_MODEL_DIR)/riscv_insts_mext.sail \
                     $(SAIL_RISCV_MODEL_DIR)/riscv_insts_zicsr.sail \
                     $(SAIL_RISCV_MODEL_DIR)/riscv_insts_hints.sail \
+                    $(SAIL_RISCV_MODEL_DIR)/riscv_insts_zba.sail \
+                    $(SAIL_RISCV_MODEL_DIR)/riscv_insts_zbb.sail \
+                    $(SAIL_RISCV_MODEL_DIR)/riscv_insts_zbc.sail \
+                    $(SAIL_RISCV_MODEL_DIR)/riscv_insts_zbs.sail \
+                    $(SAIL_RISCV_MODEL_DIR)/riscv_insts_zbkb.sail \
+                    $(SAIL_RISCV_MODEL_DIR)/riscv_insts_zbkx.sail \
                     $(SAIL_CHERI_MODEL_DIR)/cheri_insts_begin.sail \
                     $(SAIL_CHERI_MODEL_DIR)/cheri_insts.sail \
                     $(SAIL_CHERI_MODEL_DIR)/cheri_insts_cext.sail \

--- a/src/cheri_regs.sail
+++ b/src/cheri_regs.sail
@@ -150,6 +150,7 @@ function ext_init_regs () = {
   x15 = null_cap;
 
   misa->X() = 0b1;
+  misa->B() = 0b1; /* TODO this ought to be set by base model? */
   mccsr->d() = 0b1;
   mccsr->e() = 0b1;
   sccsr->d() = 0b1;


### PR DESCRIPTION
Just turning on the ratified ones for now, although Ibex supports some others.
Also force misa.B to one.
