### PR TITLE
archdoc: update LLVM attribute names to have CHERIoT prefix as they a…

### DIFF
--- a/archdoc/chap-changes.tex
+++ b/archdoc/chap-changes.tex
@@ -58,5 +58,6 @@
     \item[\ghpr{97}] Introduce the \asm{CHERIOT\_CCALL} relocation. This addresses difficulties with relaxation of compartment call relocations as per 
     \href{https://github.com/CHERIoT-Platform/llvm-project/pull/114}{CHERIoT-Platform/llvm-project/pull/114}.
     \item[\ghpr{104}, \ghpr{105}] Modify the scalar calling convention ABI to more efficiently use capability registers for small records and 64-bit floating values.
+    \item[\ghpr{112}] Change LLVM attribute prefix from \ccode{cheri} to \ccode{cheriot}.
   \end{description}
 \end{description}

--- a/archdoc/chap-language-extensions.tex
+++ b/archdoc/chap-language-extensions.tex
@@ -17,8 +17,8 @@ The compiler will raise an error if the compartment name for the current compila
 For example, if a header file contains the following declarations:
 
 \begin{ccodelisting}
-__attribute__((cheri_compartment("example"))) void foo(int);
-__attribute__((cheri_compartment("other"))) void bar(void);
+__attribute__((cheriot_compartment("example"))) void foo(int);
+__attribute__((cheriot_compartment("other"))) void bar(void);
 \end{ccodelisting}
 
 If \ccode{foo} is implemented then the compiler must be invoked with \flag{-cheri-compartment=example}.
@@ -28,12 +28,12 @@ This mechanism allows lightweight annotations on functions that are exposed acro
 Software that already supports a DLL-style linkage model may have macros on public functions for using this.
 Other software can easily maintain these annotations for CHERI targets with a macro that expands to nothing for non-CHERI targets.
 
-Adding \ccode{__attribute__((cheri_ccallback))} to a function marks it as a cross-compartment callback.
+Adding \ccode{__attribute__((cheriot_ccallback))} to a function marks it as a cross-compartment callback.
 Taking the address of such a function will give a pointer that can be passed across compartments and allow the recipient to recursively invoke this compartment.
 
 \section{Exposing library calls}
 
-Adding \ccode{__attribute__((cheri_libcall))} to a function marks it as a library call.
+Adding \ccode{__attribute__((cheriot_libcall))} to a function marks it as a library call.
 The compiler will always generate an indirect call (via a sealing capability from the import table) for all library functions, unless the callee and caller are in the same compilation unit and have compatible interrupt states.
 
 All of the functions that the compiler may insert calls to (such as \ccode{memcpy},\ccode{`__cxa_guard_acquire}, and so on) are assumed to implicitly carry this attribute.
@@ -41,20 +41,20 @@ The compiler must be able to insert calls to these without knowing the name of t
 
 \section{Controlling interrupt state}
 
-The \ccode{cheri_interrupt_state} attribute controls whether, during execution of the function, interrupts are enabled, disabled, or in whatever state there were for the caller.
+The \ccode{cheriot_interrupt_state} attribute controls whether, during execution of the function, interrupts are enabled, disabled, or in whatever state there were for the caller.
 It takes a single argument, which must be either \ccode{enabled}, \ccode{disabled}, or \ccode{inherited}.
-The attribute can also be written as a C+11 / C2x-style attribute.
+The attribute can also be written as a C++11 / C2x-style attribute.
 For example:
 
 \begin{ccodelisting}
 // This function runs with interrupts disabled
-[[cheri::interrupt_state(disabled)]]
+[[cheriot::interrupt_state(disabled)]]
 int disabled(void);
 // This function runs with interrupts enabled
-__attribute__((cheri_interrupt_state(enabled)))
+__attribute__((cheriot_interrupt_state(enabled)))
 int enabled(void);
 // This function runs with whatever interrupt state the caller has.
-__attribute__((cheri_interrupt_state(inherit)))
+__attribute__((cheriot_interrupt_state(inherit)))
 int inherit(void);
 \end{ccodelisting}
 


### PR DESCRIPTION
These are CHERIoT specific so the generic CHERI prefix is not suitable.