### PR TITLE
No functional change: simplify condition for jalr sentry types.

### DIFF
--- a/src/cheri_insts.sail
+++ b/src/cheri_insts.sail
@@ -165,11 +165,11 @@ function clause execute(CJALR(imm, cs1, cd)) = {
   let newPC = [cs1_val.address + off with 0 = bitzero]; /* clear bit zero as for RISCV JALR */
 
   let isAllowedSentryType =
-    if (cd == zreg & cs1 == ra) then
+    if (cd == zreg & cs1 == ra) then /* this looks like a return */
         isCapBackwardSentry(cs1_val)
-    else if (cd == ra) then
+    else if (cd == ra) then /* this looks like an ordinary call */
         not(isCapSealed(cs1_val)) | isCapForwardSentry(cs1_val)
-    else
+    else /* this looks like a tail or outlined call */
         not(isCapSealed(cs1_val)) | isCapForwardInheritSentry(cs1_val);
 
   if not (cs1_val.tag) then {


### PR DESCRIPTION
This occurred to me while preparing the risc-v asciidoc version.

I think this is easier to understand as the 'else' hides the tricky cases and we keep the important ones (function call and return).  I used Sail SMT to check that this is equivalent and also pulled it out to a let variable for readability.

We could optionally give the table in the text the same treatment.