### PR TITLE
Add alignment SMT property for CSetBoundsRoundDown

### DIFF
--- a/properties/Makefile
+++ b/properties/Makefile
@@ -9,7 +9,12 @@ SRCS+=proplib.sail
 SRCS+=props.sail
 SRCS+=props_setboundsrounddown.sail
 
-all: generate_smt run_smt
+SOLVER=z3
+
+auto:
+	sail ${SAIL_FLAGS} -smt -smt_auto -smt_auto_solver ${SOLVER} ${SRCS}
+
+manual: generate_smt run_smt
 
 generate_smt:
 	sail ${SAIL_FLAGS} -smt ${SRCS}
@@ -18,7 +23,7 @@ run_smt:
 	@failure=0; \
 	for prop in *.smt2; do \
 		echo -n "$$prop: "; \
-		output=$$(cvc4 $$prop); \
+		output=$$($(SOLVER) $$prop); \
 		if [ "$$output" = unsat ]; then \
 			echo "proved"; \
 		elif [ "$$output" = sat ]; then \

--- a/properties/props_setboundsrounddown.sail
+++ b/properties/props_setboundsrounddown.sail
@@ -59,3 +59,26 @@ function prop_setboundsrounddown_precise(reqBase1 : CapAddrBits, reqLen1 : CapAd
     (saneTop1 & validBase & validTop & betterTop) -->
       ((reqLen1 >=_u threshold14) & (t1 - (0b0 @ b1) == 0b0 @ threshold14))
 }
+
+/*!
+ * THIS checks that the resulting capability is aligned to at least the
+ * minimum of the requested base and length alignments (when the requested
+ * top is sane and the minimum alignment is at most 14). This is important for
+ * a use in the switcher where we want to ensure that stack pointers and bounds
+ * are aligned to at least 16 bytes as per discussion at
+ * https://github.com/CHERIoT-Platform/cheriot-rtos/pull/632 .
+ */
+$property
+function prop_setboundsrounddown_aligned(reqBase : CapAddrBits, reqLen : CapAddrBits) -> bool = {
+    let minReqAlign = min(count_trailing_zeros(reqBase),
+                          count_trailing_zeros(reqLen));
+
+    let c = setCapBoundsRoundDown(root_cap_mem, reqBase, reqLen);
+    let (resBase, resTop) = getCapBoundsBits(c);
+
+    let reqTop = (0b0 @ reqBase) + (0b0 @ reqLen);
+    let saneTop = reqTop <=_u 0b1@0x00000000;
+
+    (saneTop & (minReqAlign <= 14)) -->
+      (count_trailing_zeros(resTop) >= minReqAlign)
+}

--- a/src/cheri_cap_common.sail
+++ b/src/cheri_cap_common.sail
@@ -488,17 +488,6 @@ function setCapBounds(cap, base, length) : (Capability, CapAddrBits, CapAddrBits
   (exact, newCap)
 }
 
-/* XXX this should go in prelude.sail but putting here for now to avoid submodule faff */
-val count_trailing_zeros : forall 'N, 'N >=0 . bits('N) -> range(0, 'N)
-function count_trailing_zeros(bv) = {
-  foreach(i from 0 to ('N - 1) by 1 in inc) {
-    if bv[i] == bitone then {
-      return i;
-    }
-  };
-  'N
-}
-
 /*!
  * Returns cap with the address and base set to the given base (exactly) and the
  * length set to the largest value less than or equal to given length that can


### PR DESCRIPTION
Also default to using Sail's `-smt_auto` in `properties/Makefile`.