### PR TITLE
Remove CHERIOT_COMPARTMENT_LO_CINCOFFSET from relocations list.

### DIFF
--- a/archdoc/chap-abi.tex
+++ b/archdoc/chap-abi.tex
@@ -202,7 +202,6 @@ This would require more complex linker relaxations to retain good code size and 
 			\asm{CHERIOT_COMPARTMENT_LO_S}       & 222 & 12-bit \PCC- or \CGP-relative displacement for use in S-type instructions. \\
 			\asm{CHERIOT_COMPARTMENT_SIZE}       & 223 & The size of the referenced symbol, applied to a \insnref{CSetBounds} instruction. \\
 			\asm{CHERIOT_CCALL}                  & 224 & Deprecated. An \insnref{auipcc} and \insnref{cjal} pair which was relaxed as per \asm{CHERI_CCALL} in RISC-V CHERI, and if not was relocated as per \asm{CHERIOT_COMPARTMENT_HI} and \asm{CHERIOT_COMPARTMENT_LO_I}. \\
-			\asm{CHERIOT_COMPARTMENT_LO_CINCOFFSET} & 225 & 12-bit \PCC- or \CGP-relative displacement for use in \insnref{cincoffsetimm} instructions. This differs from \asm{CHERIOT_COMPARTMENT_LO_I} in that it may never be used on a load or store instruction. \\
 		\end{tabular}
 	\caption{\label{tab:relocs}The relocations defined for the \cherimcu{} ABI}
 	\end{center}


### PR DESCRIPTION
This was intended for implementing the AUICGP->cap table load transformation, but ended up
not being necessary. No tooling has ever supported or emitted this relocation, so we can
simply remove it.
