### PR TITLE
Add CHERIOT_COMPARTMENT_CGP_HI and clean up a stale reference to CHERIOT_COMPARTMENT_CINCOFFSET.

### DIFF
--- a/archdoc/chap-abi.tex
+++ b/archdoc/chap-abi.tex
@@ -202,7 +202,6 @@ This would require more complex linker relaxations to retain good code size and 
 			\asm{CHERIOT_COMPARTMENT_LO_S}       & 222 & 12-bit \PCC- or \CGP-relative displacement for use in S-type instructions. \\
 			\asm{CHERIOT_COMPARTMENT_SIZE}       & 223 & The size of the referenced symbol, applied to a \insnref{CSetBounds} instruction. \\
 			\asm{CHERIOT_CCALL}                  & 224 & Deprecated. An \insnref{auipcc} and \insnref{cjal} pair which was relaxed as per \asm{CHERI_CCALL} in RISC-V CHERI, and if not was relocated as per \asm{CHERIOT_COMPARTMENT_HI} and \asm{CHERIOT_COMPARTMENT_LO_I}. \\
-			\asm{CHERIOT_COMPARTMENT_LO_CINCOFFSET} & 225 & 12-bit \PCC- or \CGP-relative displacement for use in \insnref{cincoffsetimm} instructions. This differs from \asm{CHERIOT_COMPARTMENT_LO_I} in that it may never be used on a load or store instruction. \\
 		\end{tabular}
 	\caption{\label{tab:relocs}The relocations defined for the \cherimcu{} ABI}
 	\end{center}

--- a/archdoc/chap-abi.tex
+++ b/archdoc/chap-abi.tex
@@ -198,10 +198,11 @@ This would require more complex linker relaxations to retain good code size and 
 		\begin{tabular}{l|l|p{7cm}}
 			Relocation & Value & Meaning \\ \hline
 			\asm{CHERIOT_COMPARTMENT_HI}         & 220 & 20-bit, 11-bit shifted \PCC- or \CGP-relative displacement for use in \insnref{auicgp} or \insnref{auipcc}. \\
-			\asm{CHERIOT_COMPARTMENT_LO_I}       & 221 & 12-bit \PCC- or \CGP-relative displacement for use in I-type instructions. This may only be used on load and store instructions, not on \insnref{cincoffsetimm} instructions. See also \asm{CHERIOT_COMPARTMENT_LO_CINCOFFSET}. \\
+			\asm{CHERIOT_COMPARTMENT_LO_I}       & 221 & 12-bit \PCC- or \CGP-relative displacement for use in I-type instructions. \\
 			\asm{CHERIOT_COMPARTMENT_LO_S}       & 222 & 12-bit \PCC- or \CGP-relative displacement for use in S-type instructions. \\
 			\asm{CHERIOT_COMPARTMENT_SIZE}       & 223 & The size of the referenced symbol, applied to a \insnref{CSetBounds} instruction. \\
 			\asm{CHERIOT_CCALL}                  & 224 & Deprecated. An \insnref{auipcc} and \insnref{cjal} pair which was relaxed as per \asm{CHERI_CCALL} in RISC-V CHERI, and if not was relocated as per \asm{CHERIOT_COMPARTMENT_HI} and \asm{CHERIOT_COMPARTMENT_LO_I}. \\
+			\asm{CHERIT_COMPARTMENT_CGP_HI}      & 225 & 20-bit, 11-bit shifted \PCC- or \CGP-relative displacement for use in \insnref{auicgp} or \insnref{auipcc}. Guaranteed to be followed in the instruction stream by a four-byte \asm{nop}, which provides space for transforming this reference into a GOT load.\\
 		\end{tabular}
 	\caption{\label{tab:relocs}The relocations defined for the \cherimcu{} ABI}
 	\end{center}


### PR DESCRIPTION
- **Remove CHERIOT_COMPARTMENT_LO_CINCOFFSET from relocations list.**
- **Add CHERIOT_COMPARTMENT_CGP_HI and clean up a stale reference to CHERIOT_COMPARTMENT_CINCOFFSET.**
